### PR TITLE
Update `hs:DividedBy` fix incorrect logic

### DIFF
--- a/haskell/codewars/EightKyu/DividedBy/DividedBy.hs
+++ b/haskell/codewars/EightKyu/DividedBy/DividedBy.hs
@@ -6,4 +6,4 @@ isDividedby num a b = isWholeNumber num b && isWholeNumber num a
     isWholeNumber number divider = number `mod` divider == 0
 
 isDividedby2 :: Int -> Int -> Int -> Bool
-isDividedby2 num a b = (num `mod` a) && (num `mod` b)
+isDividedby2 num a b = (num `mod` a == 0) && (num `mod` b == 0)


### PR DESCRIPTION
The `isDividedby2` are incorrectly resulting on integer calculation, this due to incorrect algorithm that instead of comparing the result of **num `mod` var** to zero, it doesn't do the comparation at all.